### PR TITLE
Specify a key path precedence:

### DIFF
--- a/cmd/ecfg/main.go
+++ b/cmd/ecfg/main.go
@@ -41,7 +41,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "keydir, k",
-			Value:  "/opt/ecfg/keys",
+			Value:  "",
 			Usage:  "Directory containing ecfg keys",
 			EnvVar: "ECFG_KEYDIR",
 		},

--- a/man/ecfg-keygen.1.ronn
+++ b/man/ecfg-keygen.1.ronn
@@ -16,8 +16,9 @@ decrypting system(s).
 `-w`, `--write`
 
 :   Rather than printing the keypair to the screen, write it directly to the
-    keydir.  The public key will still be printed, but the private key will be
-    inserted into the keydir
+    keydir. The public key will still be printed, but the private key will be
+    inserted into the first writable path listed in the key paths, decribed in
+    more detail in ecfg(1).
 
 ## SEE ALSO
 

--- a/man/ecfg.1.ronn
+++ b/man/ecfg.1.ronn
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS
 
-`ecfg` `command` [`args`]
+`ecfg` [`-k`|`--keydir` *dir*] `command` [`args`]
 
 ## DESCRIPTION
 
@@ -34,11 +34,19 @@ a workflow example.
 
 :   Generate an `ecfg` keypair (alias: `ecfg g`)
 
+## GLOBAL OPTIONS
+
+`-k`, `--keydir`=*<dir>*
+
+:   Use the provided directory instead of the default key paths (decribed in
+    the KEY MANAGEMENT section)
+
 ## ENVIRONMENT
 
 `ECFG_KEYDIR`
 
-:   Override the default key lookup directory of /opt/ecfg/keys.
+:   Use a custom directory instead of the default key lookup path decribed in
+    the KEY MANAGEMENT section.
 
 `ECFG_PRIVATE_KEY`
 
@@ -46,6 +54,25 @@ a workflow example.
     public key given in the input file, assume the file was encrypted to the
     provided private key. This option is useful when running in environments
     such as heroku where obtaining keys from disk is impractical.
+
+## KEY MANAGEMENT
+
+`ecfg` keypairs are stored as individual files in a key directory. The file
+name is the public key and the file content is the private key. `ecfg` has a
+default lookup path for key directories:
+
+* `$XDG_CONFIG_HOME/ecfg/keys` (if `$XDG_CONFIG_HOME` is set and running as non-root user)
+* `$HOME/.ecfg/keys` (if running as non-root user)
+* `/etc/ecfg/keys`
+* `/opt/ejson/keys` (for backwards-compatibility with `ejson`)
+
+When passing `-k` or `--keydir` to `ecfg`, or when invoked with `ECFG_KEYDIR`
+in the environment, this lookup path is completely ignored and the key is
+instead retrieved from or stored to the provided path.
+
+If `ECFG_PRIVATE_KEY` is set for decryption, the key directories aren't even
+touched; instead, we just assume the provided private key is the correct one,
+failing if it's not.
 
 ## WORKFLOW
 

--- a/man/html/ecfg-keygen.1.html
+++ b/man/html/ecfg-keygen.1.html
@@ -93,8 +93,9 @@ decrypting system(s).</p>
 <dl>
 <dt><code>-w</code>, <code>--write</code></dt>
 <dd><p>  Rather than printing the keypair to the screen, write it directly to the
-  keydir.  The public key will still be printed, but the private key will be
-  inserted into the keydir</p></dd>
+  keydir. The public key will still be printed, but the private key will be
+  inserted into the first writable path listed in the key paths, decribed in
+  more detail in <a class="man-ref" href="ecfg.1.html">ecfg<span class="s">(1)</span></a>.</p></dd>
 </dl>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>

--- a/man/html/ecfg.1.html
+++ b/man/html/ecfg.1.html
@@ -63,7 +63,9 @@
     <a href="#SYNOPSIS">SYNOPSIS</a>
     <a href="#DESCRIPTION">DESCRIPTION</a>
     <a href="#COMMANDS">COMMANDS</a>
+    <a href="#GLOBAL-OPTIONS">GLOBAL OPTIONS</a>
     <a href="#ENVIRONMENT">ENVIRONMENT</a>
+    <a href="#KEY-MANAGEMENT">KEY MANAGEMENT</a>
     <a href="#WORKFLOW">WORKFLOW</a>
     <a href="#BUGS">BUGS</a>
     <a href="#COPYRIGHT">COPYRIGHT</a>
@@ -83,7 +85,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>ecfg</code> <code>command</code> [<code>args</code>]</p>
+<p><code>ecfg</code> [<code>-k</code>|<code>--keydir</code> <em>dir</em>] <code>command</code> [<code>args</code>]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -110,17 +112,48 @@ a workflow example.</p>
 <dd><p>  Generate an <code>ecfg</code> keypair (alias: <code>ecfg g</code>)</p></dd>
 </dl>
 
+<h2 id="GLOBAL-OPTIONS">GLOBAL OPTIONS</h2>
+
+<dl>
+<dt><code>-k</code>, <code>--keydir</code>=<em><dir /></em></dt>
+<dd><p>  Use the provided directory instead of the default key paths (decribed in
+  the KEY MANAGEMENT section)</p></dd>
+</dl>
+
 <h2 id="ENVIRONMENT">ENVIRONMENT</h2>
 
 <dl>
 <dt><code>ECFG_KEYDIR</code></dt>
-<dd><p>  Override the default key lookup directory of /opt/ecfg/keys.</p></dd>
+<dd><p>  Use a custom directory instead of the default key lookup path decribed in
+  the KEY MANAGEMENT section.</p></dd>
 <dt><code>ECFG_PRIVATE_KEY</code></dt>
 <dd><p>  When decrypting, instead of looking up the matching private key for the
   public key given in the input file, assume the file was encrypted to the
   provided private key. This option is useful when running in environments
   such as heroku where obtaining keys from disk is impractical.</p></dd>
 </dl>
+
+<h2 id="KEY-MANAGEMENT">KEY MANAGEMENT</h2>
+
+<p><code>ecfg</code> keypairs are stored as individual files in a key directory. The file
+name is the public key and the file content is the private key. <code>ecfg</code> has a
+default lookup path for key directories:</p>
+
+<ul>
+<li><code>$XDG_CONFIG_HOME/ecfg/keys</code> (if <code>$XDG_CONFIG_HOME</code> is set and running as non-root user)</li>
+<li><code>$HOME/.ecfg/keys</code> (if running as non-root user)</li>
+<li><code>/etc/ecfg/keys</code></li>
+<li><code>/opt/ejson/keys</code> (for backwards-compatibility with <code>ejson</code>)</li>
+</ul>
+
+
+<p>When passing <code>-k</code> or <code>--keydir</code> to <code>ecfg</code>, or when invoked with <code>ECFG_KEYDIR</code>
+in the environment, this lookup path is completely ignored and the key is
+instead retrieved from or stored to the provided path.</p>
+
+<p>If <code>ECFG_PRIVATE_KEY</code> is set for decryption, the key directories aren't even
+touched; instead, we just assume the provided private key is the correct one,
+failing if it's not.</p>
 
 <h2 id="WORKFLOW">WORKFLOW</h2>
 
@@ -204,8 +237,8 @@ only takes one file parameter, and prints the output to <code>stdout</code>:</p>
 
 <h2 id="BUGS">BUGS</h2>
 
-<p>Report security issues to <a href="&#x6d;&#x61;&#x69;&#x6c;&#x74;&#111;&#58;&#x62;&#x75;&#114;&#107;&#101;&#x2e;&#108;&#105;&#98;&#x62;&#x65;&#x79;&#64;&#x73;&#x68;&#111;&#x70;&#x69;&#x66;&#x79;&#x2e;&#99;&#111;&#109;" data-bare-link="true">&#x62;&#x75;&#x72;&#107;&#x65;&#46;&#108;&#105;&#x62;&#98;&#101;&#x79;&#x40;&#115;&#104;&#x6f;&#112;&#x69;&#x66;&#121;&#x2e;&#99;&#111;&#109;</a> and
-<a href="&#x6d;&#97;&#x69;&#108;&#116;&#x6f;&#58;&#x73;&#x65;&#99;&#117;&#114;&#105;&#116;&#121;&#x40;&#x73;&#104;&#x6f;&#112;&#105;&#x66;&#121;&#46;&#99;&#x6f;&#109;" data-bare-link="true">&#x73;&#x65;&#x63;&#117;&#114;&#x69;&#x74;&#121;&#x40;&#x73;&#104;&#111;&#112;&#105;&#102;&#121;&#46;&#x63;&#111;&#109;</a>.</p>
+<p>Report security issues to <a href="&#109;&#97;&#x69;&#108;&#x74;&#111;&#x3a;&#x62;&#117;&#114;&#107;&#101;&#x2e;&#x6c;&#105;&#x62;&#x62;&#101;&#x79;&#64;&#115;&#x68;&#111;&#x70;&#x69;&#102;&#x79;&#x2e;&#x63;&#111;&#x6d;" data-bare-link="true">&#x62;&#117;&#x72;&#x6b;&#x65;&#x2e;&#108;&#105;&#x62;&#98;&#x65;&#x79;&#x40;&#115;&#x68;&#111;&#x70;&#x69;&#102;&#x79;&#46;&#x63;&#x6f;&#x6d;</a> and
+<a href="&#109;&#x61;&#105;&#x6c;&#116;&#111;&#x3a;&#x73;&#x65;&#99;&#117;&#114;&#x69;&#116;&#x79;&#64;&#x73;&#104;&#x6f;&#112;&#105;&#x66;&#x79;&#x2e;&#99;&#x6f;&#x6d;" data-bare-link="true">&#115;&#101;&#99;&#117;&#114;&#105;&#116;&#121;&#64;&#x73;&#x68;&#111;&#112;&#x69;&#102;&#121;&#46;&#x63;&#x6f;&#109;</a>.</p>
 
 <p>File non-security-related bugs at <a href="https://github.com/Shopify/ecfg" data-bare-link="true">https://github.com/Shopify/ecfg</a>.</p>
 

--- a/man/man1/ecfg-keygen.1
+++ b/man/man1/ecfg-keygen.1
@@ -16,7 +16,7 @@ Generates a new keypair suitable for use with ecfg(1) and prints the resulting p
 .
 .TP
 \fB\-w\fR, \fB\-\-write\fR
-Rather than printing the keypair to the screen, write it directly to the keydir\. The public key will still be printed, but the private key will be inserted into the keydir
+Rather than printing the keypair to the screen, write it directly to the keydir\. The public key will still be printed, but the private key will be inserted into the first writable path listed in the key paths, decribed in more detail in ecfg(1)\.
 .
 .SH "SEE ALSO"
 ecfg(1), ecfg\-encrypt(1), ecfg\-decrypt(1), ecfg(5)

--- a/man/man1/ecfg.1
+++ b/man/man1/ecfg.1
@@ -7,7 +7,7 @@
 \fBecfg\fR \- manage application secrets via encrypted config
 .
 .SH "SYNOPSIS"
-\fBecfg\fR \fBcommand\fR [\fBargs\fR]
+\fBecfg\fR [\fB\-k\fR|\fB\-\-keydir\fR \fIdir\fR] \fBcommand\fR [\fBargs\fR]
 .
 .SH "DESCRIPTION"
 \fBecfg\fR is a utility for managing a collection of secrets, typically to be committed to source control\. The secrets are encrypted using public key, elliptic curve cryptography\. Secrets are collected in a JSON, YAML, or TOML file, in which all the string values are encrypted\. Public keys are embedded in the file, and the decrypter looks up the corresponding private key from its local filesystem or process environment\.
@@ -33,15 +33,44 @@ Decrypt an \fBecfg\fR file (alias: \fBecfg d\fR)
 \fBecfg keygen\fR : ecfg\-keygen(1)
 Generate an \fBecfg\fR keypair (alias: \fBecfg g\fR)
 .
+.SH "GLOBAL OPTIONS"
+.
+.TP
+\fB\-k\fR, \fB\-\-keydir\fR=\fI\fR
+Use the provided directory instead of the default key paths (decribed in the KEY MANAGEMENT section)
+.
 .SH "ENVIRONMENT"
 .
 .TP
 \fBECFG_KEYDIR\fR
-Override the default key lookup directory of /opt/ecfg/keys\.
+Use a custom directory instead of the default key lookup path decribed in the KEY MANAGEMENT section\.
 .
 .TP
 \fBECFG_PRIVATE_KEY\fR
 When decrypting, instead of looking up the matching private key for the public key given in the input file, assume the file was encrypted to the provided private key\. This option is useful when running in environments such as heroku where obtaining keys from disk is impractical\.
+.
+.SH "KEY MANAGEMENT"
+\fBecfg\fR keypairs are stored as individual files in a key directory\. The file name is the public key and the file content is the private key\. \fBecfg\fR has a default lookup path for key directories:
+.
+.IP "\(bu" 4
+\fB$XDG_CONFIG_HOME/ecfg/keys\fR (if \fB$XDG_CONFIG_HOME\fR is set and running as non\-root user)
+.
+.IP "\(bu" 4
+\fB$HOME/\.ecfg/keys\fR (if running as non\-root user)
+.
+.IP "\(bu" 4
+\fB/etc/ecfg/keys\fR
+.
+.IP "\(bu" 4
+\fB/opt/ejson/keys\fR (for backwards\-compatibility with \fBejson\fR)
+.
+.IP "" 0
+.
+.P
+When passing \fB\-k\fR or \fB\-\-keydir\fR to \fBecfg\fR, or when invoked with \fBECFG_KEYDIR\fR in the environment, this lookup path is completely ignored and the key is instead retrieved from or stored to the provided path\.
+.
+.P
+If \fBECFG_PRIVATE_KEY\fR is set for decryption, the key directories aren\'t even touched; instead, we just assume the provided private key is the correct one, failing if it\'s not\.
 .
 .SH "WORKFLOW"
 .


### PR DESCRIPTION
@Shopify/dev-infra 

* `$XDG_CONFIG_HOME/ecfg/keys` (if set, and non-root)
* `$HOME/.ecfg/keys` (if non-root)
* `/etc/ecfg/keys`
* `/opt/ejson/keys`

When decrypting, paths are searched in order.

When writing keys out with `keygen -w`, the first writable path will be used.

Ignore the diffs for `*.html` and `*.1`; they're generated from `*.ronn`.