### PR TITLE
fix: Command-line wrapper shouldn't force JSON type for files

### DIFF
--- a/cmd/ecfg/actions.go
+++ b/cmd/ecfg/actions.go
@@ -24,7 +24,7 @@ func encryptAction(filePath string, ftype ecfg.FileType) error {
 		fmt.Printf("%s", string(out))
 		return nil
 	}
-	n, err := ecfg.EncryptFileInPlace(filePath, ecfg.FileTypeJSON)
+	n, err := ecfg.EncryptFileInPlace(filePath, ftype)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func decryptAction(filePath string, keydir, outFile string, ftype ecfg.FileType)
 		return nil
 	}
 
-	decrypted, err := ecfg.DecryptFile(filePath, keypath, ecfg.FileTypeJSON)
+	decrypted, err := ecfg.DecryptFile(filePath, keypath, ftype)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I'm not sure how much activity this repo has, but this seems like a small oversight with a simple fix.